### PR TITLE
Add error handler, show acorn errors

### DIFF
--- a/blocks.html
+++ b/blocks.html
@@ -350,6 +350,7 @@
 <script type="text/javascript" src="lib/decomp.js"></script>
 <script type="text/javascript" src="lib/pathseg.js"></script>
 <script src="lib/matter.min.js"></script>
+<script src="scripts/error-handler.js"></script>
 <script src="scripts/blockly-editor.js"></script>
 <script src="scripts/robot.js"></script>
 <script src="scripts/dualbot.js"></script>

--- a/competition.html
+++ b/competition.html
@@ -566,6 +566,7 @@
 <script type="text/javascript" src="lib/decomp.js"></script>
 <script type="text/javascript" src="lib/pathseg.js"></script>
 <script src="lib/matter.min.js"></script>
+<script src="scripts/error-handler.js"></script>
 <script src="scripts/blockly-editor.js"></script>
 <script src="scripts/robot.js"></script>
 <script src="scripts/dualbot.js"></script>

--- a/javascript.html
+++ b/javascript.html
@@ -148,6 +148,7 @@
 <script type="text/javascript" src="lib/decomp.js"></script>
 <script type="text/javascript" src="lib/pathseg.js"></script>
 <script src="lib/matter.min.js"></script>
+<script src="scripts/error-handler.js"></script>
 <script src="scripts/robot.js"></script>
 <script src="scripts/dualbot.js"></script>
 <script src="scripts/tribot.js"></script>

--- a/scripts/competition.js
+++ b/scripts/competition.js
@@ -349,7 +349,7 @@ Matter.Mouse._getRelativeMousePosition = function(event, element, pixelRatio) {
     // Start simulator
     competition.startSim = function() {
         competition.moveBall(competition.loc.CENTRE, ball);
-        document.getElementById('notifications').innerHTML = '';
+        errorHandler.clear();
         let runButton = document.getElementById('run-robots');
         let stopButton = document.getElementById('stop-robots');
 

--- a/scripts/error-handler.js
+++ b/scripts/error-handler.js
@@ -1,0 +1,45 @@
+/**
+ * @description Error handling
+ */
+;(function() {
+    const errorHandler = {};
+
+    errorHandler.clear = () => {
+        document.getElementById('notifications').innerHTML = '';
+    };
+
+    errorHandler.escape = (str) => {
+          return str
+            .replace(/&/g, '&')
+            .replace(/'/g, "'")
+            .replace(/"/g, '"')
+            .replace(/>/g, '>')
+            .replace(/</g, '<')
+            .replace(/\//g, '/');
+    };
+
+    /**
+     * Adds an error message to the notifications box
+     * @param  {[type]} message Error message.
+     * @param  {[type]} type    one of 'danger', 'warning', 'success', 'info', 'link', 'primary', or empty
+     */
+    errorHandler.addError = (message, type) => {
+        const errorBox = document.createElement('div');
+        errorBox.classList.add('notification');
+        if (type) {
+            errorBox.classList.add( `is-${type}`);
+        }
+        errorBox.innerHTML = errorHandler.escape(message);
+        
+        const closeIcon = document.createElement('button');
+        closeIcon.classList.add('delete');
+        closeIcon.addEventListener('click', function() {
+            errorBox.remove();
+        });
+        errorBox.appendChild(closeIcon);
+        
+        document.getElementById('notifications').appendChild(errorBox);
+    };
+
+    window.errorHandler = errorHandler;
+})();

--- a/scripts/simcontrols.js
+++ b/scripts/simcontrols.js
@@ -229,7 +229,7 @@
         let codes = [];
         
         // Show loading
-        document.getElementById('notifications').innerHTML = '';
+        errorHandler.clear();
         let runButton = document.getElementById('run-robots');
         let stopButton = document.getElementById('stop-robots');
         let typeButton = document.getElementById('robot-type-button');
@@ -252,7 +252,7 @@
             try {
                 codes.push(Blockly.JavaScript.workspaceToCode(hiddenWorkspace));
             } catch (error) {
-                simControls.showError(error.toString());
+                errorHandler.addError(`Error: ${error.toString()}`, 'danger');
                 stopButton.setAttribute('disabled', '');
                 runButton.removeAttribute('disabled');
                 console.log(error);
@@ -267,7 +267,7 @@
         let codes = [];
         
         // Show loading
-        document.getElementById('notifications').innerHTML = '';
+        errorHandler.clear();
         let runButton = document.getElementById('run-robots');
         let stopButton = document.getElementById('stop-robots');
 
@@ -305,23 +305,6 @@
         stopButton.setAttribute('disabled', '');
         runButton.removeAttribute('disabled');
         typeButton.removeAttribute('disabled');
-    };
-
-    simControls.showError = function(message) {
-        const errorBox = document.createElement('div');
-        errorBox.classList.add('notification', 'is-danger', 'is-light');
-        errorBox.innerHTML = 'There was an problem when running your program. Please <a' + 
-        ' href="https://github.com/kcnotes/soccersim/issues" target="_blank">submit an issue on GitHub</a>.<br/>' + 
-        message;
-        
-        const closeIcon = document.createElement('button');
-        closeIcon.classList.add('delete');
-        closeIcon.addEventListener('click', function() {
-            errorBox.remove();
-        });
-        errorBox.appendChild(closeIcon);
-        
-        document.getElementById('notifications').appendChild(errorBox);
     };
 
     simControls.init = function() {

--- a/styles/soccer.css
+++ b/styles/soccer.css
@@ -136,3 +136,11 @@ line.blocklyFlyoutLine {
 #notification-modal {
     z-index: 1000;
 }
+
+#notifications {
+    text-align: left;
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    max-width: 500px;
+}


### PR DESCRIPTION
Adds error handling.
* Split displaying errors into a separate file, move errors to the bottom right corner

There's three types of errors that are now detected:
* Parsing errors - e.g. malfunctioning Blockly code, invalid JS syntax
* Startup/Running error - e.g. error found when stepping through startup/all interpreters (e.g. undefined variables)

![image](https://user-images.githubusercontent.com/5524849/131253621-88d9a290-998b-4df3-a685-70681c6cba31.png)
![image](https://user-images.githubusercontent.com/5524849/131253652-b75de41e-30aa-42c7-877a-0012043e844e.png)
![image](https://user-images.githubusercontent.com/5524849/131253664-2d14bc91-117e-4427-a9fc-65b8ce698d36.png)
